### PR TITLE
Work around name collision with NSTextRange initWithLocation

### DIFF
--- a/src/private/WRLDBuildingHighlightOptions+Private.h
+++ b/src/private/WRLDBuildingHighlightOptions+Private.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WRLDBuildingHighlightOptions (Private)
 
-- (instancetype) initWithLocation:(CLLocationCoordinate2D)location;
+- (instancetype) initWithLocation2:(CLLocationCoordinate2D)location;
 
 - (instancetype) initWithScreenPoint:(CGPoint)screenPoint;
 

--- a/src/private/WRLDBuildingHighlightOptions.mm
+++ b/src/private/WRLDBuildingHighlightOptions.mm
@@ -16,7 +16,7 @@
 
 + (instancetype) highlightOptionsWithLocation:(CLLocationCoordinate2D)location
 {
-    return [[self alloc] initWithLocation:location];
+    return [[self alloc] initWithLocation2:location];
 }
 
 + (instancetype) highlightOptionsWithScreenPoint:(CGPoint)screenPoint
@@ -24,7 +24,7 @@
     return [[self alloc] initWithScreenPoint:screenPoint];
 }
 
-- (instancetype) initWithLocation:(CLLocationCoordinate2D)location
+- (instancetype) initWithLocation2:(CLLocationCoordinate2D)location
 {
     self = [super init];
     if (self)


### PR DESCRIPTION
I'm not entirely sure why this is necessary. Something I read suggested that potentially the `[self alloc]` is returning a generic type, so the compiler searches all known types for candidate methods. The advice for that situation was to add an explicit cast, but doing so gave syntax errors, despite everything matching the most similar examples I could find.

Instead, I just did manual name mangling by adding a `2` to the method name.

Hopefully, we've still got employees who have some vague familiarity with Objective-C/Objective-C++ and one of them can fix this properly before we're forced to put this into production code. It can live as a draft PR until then.